### PR TITLE
Update L09 Tuples, Lists and Dictionaries.ipynb

### DIFF
--- a/lecture_notebooks/L09 Tuples, Lists and Dictionaries.ipynb
+++ b/lecture_notebooks/L09 Tuples, Lists and Dictionaries.ipynb
@@ -2780,7 +2780,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "the length is: 4\n"
+      "the length is: 2\n"
      ]
     }
    ],


### PR DESCRIPTION
In a comment it said the length is 4 when it should be 2, because there are only 2 strings in that list