### PR TITLE
Typo fix in L05, line 1110

### DIFF
--- a/lecture_notebooks/L05 Loops.ipynb
+++ b/lecture_notebooks/L05 Loops.ipynb
@@ -1107,7 +1107,7 @@
     "  if i < 5:\n",
     "    print(\"skipping \" + str(i))\n",
     "\n",
-    "    continue # This says go back to the top of the loop and evalute\n",
+    "    continue # This says go back to the top of the loop and evaluate\n",
     "    # the loop conditional\n",
     "  \n",
     "  print(\"adding\", i)\n",


### PR DESCRIPTION
A minor typo fix: Change "the loop and evalute" to "the loop and evaluate"